### PR TITLE
Fix "Wifi Animations" partially hidden

### DIFF
--- a/Animatify/Code/Modules/Home/Base.lproj/Home.storyboard
+++ b/Animatify/Code/Modules/Home/Base.lproj/Home.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="mcr-oN-7n4">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="mcr-oN-7n4">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -107,6 +108,7 @@
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" name="background"/>
                         <constraints>
                             <constraint firstItem="cC9-r2-4Z4" firstAttribute="top" secondItem="rdI-XQ-PDr" secondAttribute="bottom" constant="24" id="1BN-1Y-Cdn"/>
@@ -130,11 +132,11 @@
                             <constraint firstItem="lz0-SH-1tv" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="oxQ-us-c3J"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="cC9-r2-4Z4" secondAttribute="bottom" id="uob-j4-vhY"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <navigationItem key="navigationItem" id="5ZC-k0-eNY"/>
                     <connections>
                         <outlet property="containerView" destination="Zxn-jI-eeW" id="kGb-4U-PCQ"/>
+                        <outlet property="containerViewBottomConstraint" destination="bZF-cm-zGX" id="8wl-nK-oS0"/>
                         <outlet property="effectsCollectionView" destination="r7Q-pM-Gcm" id="Ud9-qN-cbA"/>
                         <outlet property="expandButton" destination="JvB-17-mX3" id="dPL-ej-sQS"/>
                         <outlet property="logoView" destination="lz0-SH-1tv" id="yA6-W1-up6"/>
@@ -235,6 +237,7 @@
                                 </constraints>
                             </scrollView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="nr2-8t-xaV"/>
                         <color key="backgroundColor" name="background"/>
                         <constraints>
                             <constraint firstItem="pcU-t0-J7R" firstAttribute="leading" secondItem="nr2-8t-xaV" secondAttribute="leading" id="01L-pd-KHg"/>
@@ -252,7 +255,6 @@
                             <constraint firstItem="Raz-cw-0ZC" firstAttribute="leading" secondItem="nr2-8t-xaV" secondAttribute="leading" constant="24" id="lUN-24-dC0"/>
                             <constraint firstItem="nr2-8t-xaV" firstAttribute="trailing" secondItem="pcU-t0-J7R" secondAttribute="trailing" id="zHE-Mi-LOv"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="nr2-8t-xaV"/>
                     </view>
                     <connections>
                         <outlet property="backButton" destination="XY6-Eq-UhV" id="5sZ-HT-Mka"/>
@@ -371,6 +373,7 @@
                                 </constraints>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="1S6-jq-MSa"/>
                         <color key="backgroundColor" name="background"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="Foq-Ly-u4I" secondAttribute="trailing" id="3f6-zq-bF5"/>
@@ -390,7 +393,6 @@
                             <constraint firstItem="1S6-jq-MSa" firstAttribute="trailing" secondItem="ILC-iU-Cue" secondAttribute="trailing" constant="24" id="knW-iR-MBZ"/>
                             <constraint firstAttribute="bottom" secondItem="Foq-Ly-u4I" secondAttribute="bottom" id="nER-yR-6ve"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="1S6-jq-MSa"/>
                     </view>
                     <connections>
                         <outlet property="descriptionTextView" destination="bM7-wE-70p" id="X7K-Qv-MzU"/>
@@ -414,8 +416,8 @@
                     <view key="view" contentMode="scaleToFill" id="utp-af-Bf2">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" name="alternateBackground"/>
                         <viewLayoutGuide key="safeArea" id="tEx-cj-y5N"/>
+                        <color key="backgroundColor" name="alternateBackground"/>
                     </view>
                     <navigationItem key="navigationItem" id="1EX-gr-kjC"/>
                 </viewController>

--- a/Animatify/Code/Modules/Home/HomeViewController.swift
+++ b/Animatify/Code/Modules/Home/HomeViewController.swift
@@ -16,6 +16,7 @@ class HomeViewController: UIViewController {
     
     // MARK:- outlets for the viewController
     @IBOutlet weak var containerView: UIView!
+    @IBOutlet weak var containerViewBottomConstraint: NSLayoutConstraint! /// for animating the collapse/expand of the "Tutorials" view
     @IBOutlet weak var expandButton: UIButton!
     @IBOutlet weak var logoView: UIView!
     @IBOutlet weak var effectsCollectionView: UICollectionView!
@@ -82,14 +83,25 @@ class HomeViewController: UIViewController {
         self.drawLogo()
     }
     
+    /// animations must be called inside `viewDidAppear` or later (not in `viewDidLoad`)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        setupContainer()
+    }
+    
     
     // MARK:- action outlets for the viewController
     @IBAction func expandButtonPressed(_ sender: Any) {
+        if self.containerToggled {
+            self.containerViewBottomConstraint.constant = 0 /// reset to normal
+        } else {
+            let bottomConstant = 100 - containerView.frame.size.height /// show a bit of the top
+            self.containerViewBottomConstraint.constant = bottomConstant
+        }
+        
         ViewAnimationFactory.makeEaseInOutAnimation(duration: 0.75, delay: 0) {
             self.expandButton.transform = self.expandButton.transform.rotated(by: +CGFloat.pi + 0.00000001)
-            var containerViewTransform = CGAffineTransform.identity
-            containerViewTransform = containerViewTransform.translatedBy(x: 0, y: self.view.frame.height - self.containerView.frame.origin.y - 100)
-            self.containerView.transform = containerViewTransform
+            self.view.layoutIfNeeded()
             self.containerToggled = !self.containerToggled
         }
     }
@@ -101,10 +113,16 @@ class HomeViewController: UIViewController {
         
         // set the section to collapsed
         self.expandButton.transform = self.expandButton.transform.rotated(by: +CGFloat.pi + 0.00000001)
-        var containerViewTransform = CGAffineTransform.identity
-        containerViewTransform = containerViewTransform.translatedBy(x: 0, y: self.view.frame.height - self.containerView.frame.origin.y - 100)
-        self.containerView.transform = containerViewTransform
         self.containerToggled = !self.containerToggled
+    }
+    
+    /// animate the "Tutorial" tableview hidden
+    func setupContainer() {
+        let bottomConstant = 100 - containerView.frame.size.height /// show a bit of the top
+        self.containerViewBottomConstraint.constant = bottomConstant
+        ViewAnimationFactory.makeEaseOutAnimation(duration: 0.25, delay: 0, action: {
+            self.view.layoutIfNeeded()
+        })
     }
     
     func drawLogo(){

--- a/Animatify/Code/Modules/Home/HomeViewController.swift
+++ b/Animatify/Code/Modules/Home/HomeViewController.swift
@@ -83,7 +83,6 @@ class HomeViewController: UIViewController {
         self.drawLogo()
     }
     
-    /// animations must be called inside `viewDidAppear` or later (not in `viewDidLoad`)
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         setupContainer()
@@ -95,7 +94,7 @@ class HomeViewController: UIViewController {
         if self.containerToggled {
             self.containerViewBottomConstraint.constant = 0 /// reset to normal
         } else {
-            let bottomConstant = 100 - containerView.frame.size.height /// show a bit of the top
+            let bottomConstant = 80 - containerView.frame.size.height /// show a bit of the top
             self.containerViewBottomConstraint.constant = bottomConstant
         }
         
@@ -109,6 +108,7 @@ class HomeViewController: UIViewController {
     // MARK:- utility functions for the viewController
     func setupViews() {
         self.containerView.roundCorners(cornerRadius: 42)
+        self.containerView.alpha = 0 /// hide it at first
         self.logoView.backgroundColor = UIColor.clear
         
         // set the section to collapsed
@@ -117,11 +117,13 @@ class HomeViewController: UIViewController {
     }
     
     /// animate the "Tutorial" tableview hidden
+    /// if the tableView is collapsed inside `viewDidLoad`, it won't populate.
+    /// that's why it's **not collapsed + alpha 0** inside `viewDidLoad`, and **collapsed + alpha 1** in `viewDidAppear`.
     func setupContainer() {
-        let bottomConstant = 100 - containerView.frame.size.height /// show a bit of the top
+        let bottomConstant = 80 - self.containerView.frame.size.height /// show a bit of the top
         self.containerViewBottomConstraint.constant = bottomConstant
-        ViewAnimationFactory.makeEaseOutAnimation(duration: 0.25, delay: 0, action: {
-            self.view.layoutIfNeeded()
+        ViewAnimationFactory.makeEaseOutAnimation(duration: 0.4, delay: 0, action: {
+            self.containerView.alpha = 1
         })
     }
     

--- a/Animatify/Code/Modules/Tutorials/Cells/SnapCollectionViewCell.xib
+++ b/Animatify/Code/Modules/Tutorials/Cells/SnapCollectionViewCell.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -45,6 +46,7 @@
                     </label>
                 </subviews>
             </view>
+            <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
                 <constraint firstItem="gXm-21-lPV" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="6e4-KP-a6m"/>
                 <constraint firstAttribute="trailing" secondItem="jGx-Aw-Jl1" secondAttribute="trailing" id="PbI-uN-twe"/>
@@ -54,7 +56,6 @@
                 <constraint firstItem="jGx-Aw-Jl1" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="km4-KF-Ndo"/>
                 <constraint firstItem="jGx-Aw-Jl1" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="rd8-sU-hR3"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <connections>
                 <outlet property="movieDirectorLabel" destination="PER-Kr-aWs" id="yGf-oU-Wh5"/>
                 <outlet property="movieImageView" destination="jGx-Aw-Jl1" id="kWr-Be-Osh"/>

--- a/Animatify/Code/Modules/Tutorials/Cells/TableAnimationViewCell.xib
+++ b/Animatify/Code/Modules/Tutorials/Cells/TableAnimationViewCell.xib
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,7 +21,7 @@
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mLz-9I-xMi">
                         <rect key="frame" x="12" y="5" width="296" height="54"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </subviews>
                 <color key="backgroundColor" name="background"/>
@@ -41,5 +43,8 @@
         <namedColor name="background">
             <color red="0.12549019607843137" green="0.12941176470588237" blue="0.15294117647058825" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Animatify/Code/Modules/Tutorials/Tutorial.storyboard
+++ b/Animatify/Code/Modules/Tutorials/Tutorial.storyboard
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -37,7 +39,7 @@
                                         <constraints>
                                             <constraint firstAttribute="height" constant="42" id="mOs-6z-gEY"/>
                                         </constraints>
-                                        <color key="tintColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="tintColor" systemColor="systemTealColor"/>
                                         <state key="normal" image="1.circle.fill" catalog="system">
                                             <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="26" scale="large" weight="semibold"/>
                                         </state>
@@ -50,7 +52,7 @@
                                         <constraints>
                                             <constraint firstAttribute="height" constant="42" id="V2l-a0-JeE"/>
                                         </constraints>
-                                        <color key="tintColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="tintColor" systemColor="systemTealColor"/>
                                         <state key="normal" image="2.circle" catalog="system">
                                             <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="26" scale="large" weight="semibold"/>
                                         </state>
@@ -63,7 +65,7 @@
                                         <constraints>
                                             <constraint firstAttribute="height" constant="42" id="oq9-kk-NEh"/>
                                         </constraints>
-                                        <color key="tintColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="tintColor" systemColor="systemTealColor"/>
                                         <state key="normal" image="3.circle" catalog="system">
                                             <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="26" scale="large" weight="semibold"/>
                                         </state>
@@ -76,7 +78,7 @@
                                         <constraints>
                                             <constraint firstAttribute="height" constant="42" id="Zg2-n8-GJ7"/>
                                         </constraints>
-                                        <color key="tintColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="tintColor" systemColor="systemTealColor"/>
                                         <state key="normal" image="4.circle" catalog="system">
                                             <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="26" scale="large" weight="semibold"/>
                                         </state>
@@ -93,6 +95,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="t4a-m3-5PU"/>
                         <color key="backgroundColor" name="background"/>
                         <constraints>
                             <constraint firstItem="t4a-m3-5PU" firstAttribute="trailing" secondItem="lIw-g4-8il" secondAttribute="trailing" constant="24" id="28y-uI-HDc"/>
@@ -107,7 +110,6 @@
                             <constraint firstItem="thI-Yg-Kgx" firstAttribute="height" secondItem="LOU-4t-Chu" secondAttribute="height" multiplier="0.75" id="rva-8c-F3T"/>
                             <constraint firstItem="thI-Yg-Kgx" firstAttribute="leading" secondItem="t4a-m3-5PU" secondAttribute="leading" id="vzX-2b-Wlz"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="t4a-m3-5PU"/>
                     </view>
                     <connections>
                         <outlet property="button1" destination="svH-Hv-dIQ" id="yvd-hA-qQn"/>
@@ -129,8 +131,8 @@
                     <view key="view" contentMode="scaleToFill" id="YWk-sI-rCO">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" name="background"/>
                         <viewLayoutGuide key="safeArea" id="qse-Gw-jcR"/>
+                        <color key="backgroundColor" name="background"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fDc-DW-wMa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -176,6 +178,7 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="FNp-Xt-UO4"/>
                         <color key="backgroundColor" name="background"/>
                         <constraints>
                             <constraint firstItem="uD9-A8-Kde" firstAttribute="top" secondItem="FNp-Xt-UO4" secondAttribute="top" constant="20" id="1rx-iy-Srx"/>
@@ -188,7 +191,6 @@
                             <constraint firstItem="pyP-9s-SYy" firstAttribute="leading" secondItem="FNp-Xt-UO4" secondAttribute="leading" constant="24" id="rVF-MK-qfR"/>
                             <constraint firstItem="FNp-Xt-UO4" firstAttribute="trailing" secondItem="uWh-81-S0x" secondAttribute="trailing" constant="24" id="umC-81-0lD"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="FNp-Xt-UO4"/>
                     </view>
                     <connections>
                         <outlet property="collectionView" destination="pyP-9s-SYy" id="P3Q-GF-21l"/>
@@ -223,6 +225,7 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="3Rb-DY-2dz"/>
                         <color key="backgroundColor" name="background"/>
                         <constraints>
                             <constraint firstItem="3Rb-DY-2dz" firstAttribute="trailing" secondItem="Mhr-Ug-iba" secondAttribute="trailing" constant="84" id="5dm-1R-Kir"/>
@@ -231,7 +234,6 @@
                             <constraint firstItem="sUD-Xh-SjC" firstAttribute="top" secondItem="3Rb-DY-2dz" secondAttribute="top" constant="20" id="VEq-cB-DNS"/>
                             <constraint firstItem="Mhr-Ug-iba" firstAttribute="top" secondItem="sUD-Xh-SjC" secondAttribute="bottom" constant="180" id="mg1-dB-2Z3"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="3Rb-DY-2dz"/>
                     </view>
                     <connections>
                         <outlet property="titleLabel" destination="sUD-Xh-SjC" id="vmc-by-eaq"/>
@@ -250,5 +252,8 @@
         <namedColor name="background">
             <color red="0.12549019607843137" green="0.12941176470588237" blue="0.15294117647058825" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="systemTealColor">
+            <color red="0.35294117647058826" green="0.78431372549019607" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ An iOS application/project, that contains various classes/tutorials for effects,
 - Text-Type & Text-Gradient Effects.
 - Image Transition.
 
-![alt text](https://github.com/Shubham0812/Animatify-ios/blob/master/Animatify/Screenshots/1.png)
-![text-effects](https://raw.githubusercontent.com/Shubham0812/Test-Angular/master/docs/1.png)
-![image-transitions](https://raw.githubusercontent.com/Shubham0812/Test-Angular/master/docs/2.png)
+<img src="https://raw.githubusercontent.com/aheze/DeveloperAssets/master/0905733C-6EA7-4C4B-8C43-1A22000D6B8B.gif" width="300"> | <img src="https://raw.githubusercontent.com/aheze/DeveloperAssets/master/texttypeeffects.png" width="300"> | <img src="https://raw.githubusercontent.com/aheze/DeveloperAssets/master/B68CAFA5-97AD-4194-9B52-22A4A133EBF9.gif" width="300">
+ --- | --- | ---
+ 
 ## Languages / Frameworks Used
 - Swift 5
 - UIKit


### PR DESCRIPTION
Instead of animating the `CGAffineTransform` for the container view, I animate the bottom constraint instead. This way the bottom cell (Wifi Animations) doesn't get clipped.
Old | New
--- | --- 
![11EFC2BC-25DB-48A0-A403-CD3D67959649](https://user-images.githubusercontent.com/49819455/95142531-bf082380-0728-11eb-90ef-ee453491121e.gif) | ![AB74BAB9-0FFC-49F4-8625-A481B315A285](https://user-images.githubusercontent.com/49819455/95142510-b57ebb80-0728-11eb-9bd3-a22c69eb03f8.gif)

Side effect: The `collectionView` that's inside  `containerView` can't be collapsed inside `viewDidLoad` (because the entire `collectionView` must be displayed at first, or it won't show up at all). So, I set the alpha to 0 inside `viewDidLoad`, and in `viewDidAppear`, I set it to 1 and collapse the `collectionView`.


