### PR TITLE
Add gifs to README, embed in table

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ An iOS application/project, that contains various classes/tutorials for effects,
 - Text-Type & Text-Gradient Effects.
 - Image Transition.
 
-![alt text](https://github.com/Shubham0812/Animatify-ios/blob/master/Animatify/Screenshots/1.png)
-![text-effects](https://raw.githubusercontent.com/Shubham0812/Test-Angular/master/docs/1.png)
-![image-transitions](https://raw.githubusercontent.com/Shubham0812/Test-Angular/master/docs/2.png)
+<img src="https://raw.githubusercontent.com/aheze/DeveloperAssets/master/0905733C-6EA7-4C4B-8C43-1A22000D6B8B.gif" width="300"> | <img src="https://raw.githubusercontent.com/aheze/DeveloperAssets/master/texttypeeffects.png" width="300"> | <img src="https://raw.githubusercontent.com/aheze/DeveloperAssets/master/B68CAFA5-97AD-4194-9B52-22A4A133EBF9.gif" width="300">
+ --- | --- | ---
+ 
 ## Languages / Frameworks Used
 - Swift 5
 - UIKit


### PR DESCRIPTION
### The README currently looks like this:
![Shot 2020-10-07 at 9 38 59 AM](https://user-images.githubusercontent.com/49819455/95361128-2f29bd00-0881-11eb-8ea1-e18ab4eb0296.png)
The third image overflows, and they have different corner radiuses.

### Here's what it looks like now:
![Shot 2020-10-07 at 9 40 19 AM](https://user-images.githubusercontent.com/49819455/95361213-4bc5f500-0881-11eb-9d66-f3d005d48643.png)

### What's changed:
- Make all corner radiuses the same
- Record footage of the screenshots and convert to gif
- Add progress bar to the gifs
- Embed gifs inside table (so it will look good and not overflow)
