### PR TITLE
Fix ipad buttons

### DIFF
--- a/Animatify/Code/Modules/Home/EffectDetailsViewController.swift
+++ b/Animatify/Code/Modules/Home/EffectDetailsViewController.swift
@@ -67,7 +67,8 @@ class EffectDetailsViewController: UIViewController {
     
     // MARK:- utility functions for the viewController
     func setupViews(){
-        DispatchQueue.main.async { [self] in 
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
             self.expandButton.transform = self.expandButton.transform.rotated(by: +CGFloat.pi + 0.00000001)
             var scrollViewTransform = CGAffineTransform.identity
             scrollViewTransform = scrollViewTransform.translatedBy(x: 0, y: self.view.frame.height - self.scrollView.frame.origin.y - 80)
@@ -76,18 +77,18 @@ class EffectDetailsViewController: UIViewController {
             ///setting the effectscontainerView
             self.effectContainerView.roundCorners(cornerRadius: 12)
             let gradient = CAGradientLayer()
-            gradient.setGradientLayer(color1: effect!.gradientColor1, color2: effect!.gradientColor2, for: self.effectContainerView, cornerRadius: self.effectContainerView.layer.cornerRadius)
+            gradient.setGradientLayer(color1: self.effect!.gradientColor1, color2: self.effect!.gradientColor2, for: self.effectContainerView, cornerRadius: self.effectContainerView.layer.cornerRadius)
             self.effectContainerView.layer.addSublayer(gradient)
             
-            if (effect?.action == EffectType.pulse) {
+            if (self.effect?.action == EffectType.pulse) {
                 let pulseLayer = PulseLayer(radius: 12, for: self.effectContainerView, scale: 1.5, with: UIColor.systemIndigo.withAlphaComponent(0.8), animationDuration: 1.25)
                 self.view.layer.insertSublayer(pulseLayer, below: self.effectContainerView.layer)
-            } else if (effect?.action == EffectType.shimmer) {
-                let shimmerLayer = ShimmerLayer(for: effectContainerView, cornerRadius: 12)
-                self.view.layer.insertSublayer(shimmerLayer, above: effectContainerView.layer)
+            } else if (self.effect?.action == EffectType.shimmer) {
+                let shimmerLayer = ShimmerLayer(for: self.effectContainerView, cornerRadius: 12)
+                self.view.layer.insertSublayer(shimmerLayer, above: self.effectContainerView.layer)
                 shimmerLayer.startAnimation()
             }
-            setInstructions()
+            self.setInstructions()
         }
     }
     

--- a/Animatify/Code/Modules/Tutorials/ButtonsViewController.swift
+++ b/Animatify/Code/Modules/Tutorials/ButtonsViewController.swift
@@ -28,15 +28,10 @@ class ButtonEffectsViewController: UIViewController {
     
     private var circleSymbolNames = ["calendar.circle", "flag.circle", "link.circle", "tag.circle", "bell.circle", "envelope.circle"]
     
-    private var dX: CGFloat = 20
-    private var dY: CGFloat = 0
-    
-    private var spacing: CGFloat = 56
+    private var spacing: CGFloat = 20
     
     private var expandWidth: CGFloat = 300
     private var expandHeight: CGFloat = 300
-    
-    private var didLayoutButtons: Bool = false
     
     var upExpand = ExpandingButtonsView()
     var downExpand = ExpandingButtonsView()
@@ -44,8 +39,8 @@ class ButtonEffectsViewController: UIViewController {
     var leftExpand = ExpandingButtonsView()
     
     // MARK:- lifecycle methods for the viewController    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
+    override func viewDidLoad() {
+        super.viewDidLoad()
         drawButtons()
     }
     
@@ -57,26 +52,61 @@ class ButtonEffectsViewController: UIViewController {
     
     // MARK:- utility functions for the viewController
     func drawButtons() {
-        guard !didLayoutButtons else { return }
-        didLayoutButtons = true
         
-        self.dY = titleLabel.frame.origin.x + titleLabel.frame.height + spacing
         /// rightExpand view
-        self.rightExpand = ExpandingButtonsView(frame: CGRect(x: dX, y: dY, width: expandWidth, height: expandHeight), numberOfButtons: 3, symbolNames: symbolNames, symbolTint: symbolTint.shuffled(), expandDirection: .right, largeButtonSize: 46, smallButtonSize: 32)
+        self.rightExpand = ExpandingButtonsView(numberOfButtons: 3,
+                                                symbolNames: symbolNames,
+                                                symbolTint: symbolTint.shuffled(),
+                                                expandDirection: .right,
+                                                largeButtonSize: 46,
+                                                smallButtonSize: 32)
         self.view.addSubview(rightExpand)
-        
+        self.rightExpand.translatesAutoresizingMaskIntoConstraints = false
+        self.rightExpand.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: spacing).isActive = true
+        self.rightExpand.topAnchor.constraint(equalTo: self.titleLabel.bottomAnchor, constant: spacing).isActive = true
+        self.rightExpand.widthAnchor.constraint(equalToConstant: self.rightExpand.expandedSize().width).isActive = true
+        self.rightExpand.heightAnchor.constraint(equalToConstant: self.rightExpand.expandedSize().height).isActive = true
         
         /// leftExpand view
-        self.leftExpand = ExpandingButtonsView(frame: CGRect(x: self.view.frame.width  - (expandWidth + spacing / 2), y: self.view.frame.height - (expandHeight / 2) - (spacing / 1.45), width: expandWidth, height: expandHeight), numberOfButtons: 2, symbolNames: symbolNames, symbolTint: symbolTint.shuffled(), expandDirection: .left,  largeButtonSize: 46, smallButtonSize: 32)
+        self.leftExpand = ExpandingButtonsView(numberOfButtons: 2,
+                                               symbolNames: symbolNames,
+                                               symbolTint: symbolTint.shuffled(),
+                                               expandDirection: .left,
+                                               largeButtonSize: 46,
+                                               smallButtonSize: 32)
         self.view.addSubview(leftExpand)
+        self.leftExpand.translatesAutoresizingMaskIntoConstraints = false
+        self.leftExpand.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -spacing).isActive = true
+        self.leftExpand.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -spacing).isActive = true
+        self.leftExpand.widthAnchor.constraint(equalToConstant: self.leftExpand.expandedSize().width).isActive = true
+        self.leftExpand.heightAnchor.constraint(equalToConstant: self.leftExpand.expandedSize().height).isActive = true
         
         /// topExpand view
-        self.upExpand = ExpandingButtonsView(frame: CGRect(x: dX, y: self.view.frame.height - (expandHeight / 1.15), width: expandWidth / 4, height: expandHeight / 2), numberOfButtons: 4, symbolNames: circleSymbolNames.shuffled(), symbolTint: symbolTint.shuffled(), expandDirection: .up,  largeButtonSize: 46, smallButtonSize: 32)
+        self.upExpand = ExpandingButtonsView(numberOfButtons: 4,
+                                             symbolNames: circleSymbolNames.shuffled(),
+                                             symbolTint: symbolTint.shuffled(),
+                                             expandDirection: .up,
+                                             largeButtonSize: 46,
+                                             smallButtonSize: 32)
         self.view.addSubview(upExpand)
+        self.upExpand.translatesAutoresizingMaskIntoConstraints = false
+        self.upExpand.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: spacing).isActive = true
+        self.upExpand.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -spacing).isActive = true
+        self.upExpand.widthAnchor.constraint(equalToConstant: self.upExpand.expandedSize().width).isActive = true
+        self.upExpand.heightAnchor.constraint(equalToConstant: self.upExpand.expandedSize().height).isActive = true
         
         /// downExpand view
-        self.downExpand = ExpandingButtonsView(frame: CGRect(x: self.view.frame.width - expandWidth / 2.1, y: dY, width: expandWidth / 2, height: expandHeight), numberOfButtons: 6, symbolNames: circleSymbolNames.shuffled(), symbolTint: symbolTint.shuffled(), expandDirection: .down,  largeButtonSize: 46, smallButtonSize: 32)
+        self.downExpand = ExpandingButtonsView(numberOfButtons: 6,
+                                               symbolNames: circleSymbolNames.shuffled(),
+                                               symbolTint: symbolTint.shuffled(),
+                                               expandDirection: .down,
+                                               largeButtonSize: 46,
+                                               smallButtonSize: 32)
         self.view.addSubview(downExpand)
-        
+        self.downExpand.translatesAutoresizingMaskIntoConstraints = false
+        self.downExpand.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -spacing).isActive = true
+        self.downExpand.topAnchor.constraint(equalTo: self.titleLabel.bottomAnchor, constant: spacing).isActive = true
+        self.downExpand.widthAnchor.constraint(equalToConstant: self.downExpand.expandedSize().width).isActive = true
+        self.downExpand.heightAnchor.constraint(equalToConstant: self.downExpand.expandedSize().height).isActive = true
     }
 }

--- a/Animatify/Code/Modules/Tutorials/ButtonsViewController.swift
+++ b/Animatify/Code/Modules/Tutorials/ButtonsViewController.swift
@@ -36,16 +36,16 @@ class ButtonEffectsViewController: UIViewController {
     private var expandWidth: CGFloat = 300
     private var expandHeight: CGFloat = 300
     
+    private var didLayoutButtons: Bool = false
+    
     var upExpand = ExpandingButtonsView()
     var downExpand = ExpandingButtonsView()
     var rightExpand = ExpandingButtonsView()
     var leftExpand = ExpandingButtonsView()
     
-    // MARK:- lifecycle methods for the viewController
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        self.dY = titleLabel.frame.origin.x + titleLabel.frame.height + spacing
+    // MARK:- lifecycle methods for the viewController    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         drawButtons()
     }
     
@@ -57,6 +57,10 @@ class ButtonEffectsViewController: UIViewController {
     
     // MARK:- utility functions for the viewController
     func drawButtons() {
+        guard !didLayoutButtons else { return }
+        didLayoutButtons = true
+        
+        self.dY = titleLabel.frame.origin.x + titleLabel.frame.height + spacing
         /// rightExpand view
         self.rightExpand = ExpandingButtonsView(frame: CGRect(x: dX, y: dY, width: expandWidth, height: expandHeight), numberOfButtons: 3, symbolNames: symbolNames, symbolTint: symbolTint.shuffled(), expandDirection: .right, largeButtonSize: 46, smallButtonSize: 32)
         self.view.addSubview(rightExpand)

--- a/Animatify/Components/ExpandingButtonsView.swift
+++ b/Animatify/Components/ExpandingButtonsView.swift
@@ -81,6 +81,7 @@ class ExpandingButtonsView: UIView {
         super.init(frame: frame)
     }
     
+    /// returns the size the view will have when expanded
     public func expandedSize() -> CGSize {
         var majorDimension: CGFloat = primaryButtonWidth
         majorDimension += CGFloat(numberOfButtons) * secondaryButtonWidth

--- a/Animatify/Components/ExpandingButtonsView.swift
+++ b/Animatify/Components/ExpandingButtonsView.swift
@@ -49,8 +49,8 @@ class ExpandingButtonsView: UIView {
     /// expandDirection - an enum specifying the direction of the expansion
     /// largeButtonSize - buttonSize for the primary button
     /// smallButtonSize - buttonSize for the additional buttons
-    init(frame: CGRect, numberOfButtons: Int, symbolNames: [String], symbolTint: [UIColor], expandDirection: ExpandDirection, largeButtonSize: CGFloat, smallButtonSize: CGFloat) {
-        super.init(frame: frame)
+    init(numberOfButtons: Int, symbolNames: [String], symbolTint: [UIColor], expandDirection: ExpandDirection, largeButtonSize: CGFloat, smallButtonSize: CGFloat) {
+        super.init(frame: .zero)
         self.numberOfButtons = numberOfButtons
         self.symbolNames = symbolNames
         self.symbolTint = symbolTint
@@ -81,6 +81,15 @@ class ExpandingButtonsView: UIView {
         super.init(frame: frame)
     }
     
+    public func expandedSize() -> CGSize {
+        var majorDimension: CGFloat = primaryButtonWidth
+        majorDimension += CGFloat(numberOfButtons) * secondaryButtonWidth
+        if self.expandDirection == .up || self.expandDirection == .down {
+            return CGSize(width: primaryButtonWidth, height: majorDimension)
+        }
+        return CGSize(width: majorDimension, height: primaryButtonWidth)
+    }
+    
     // MARK:- functions for the view
     func setButtons() {
         
@@ -98,7 +107,10 @@ class ExpandingButtonsView: UIView {
         
         /// adding the primary button, this is the button that gets expanded
         let primaryButton = UIButton(type: .system)
-        primaryButton.frame = CGRect(x: cX - (primaryButtonWidth) / 2, y: cY - (primaryButtonWidth) / 2, width: primaryButtonWidth, height: primaryButtonWidth)
+        let primaryButtonOriginX = self.expandDirection == .right ? 0 : expandedSize().width - primaryButtonWidth
+        let primaryButtonOriginY = self.expandDirection == .down ? 0 : expandedSize().height - primaryButtonWidth
+        
+        primaryButton.frame = CGRect(x: primaryButtonOriginX , y: primaryButtonOriginY , width: primaryButtonWidth, height: primaryButtonWidth)
         primaryButton.layer.borderColor = UIColor.orange.cgColor
         primaryButton.setImage(UIImage(systemName: "plus.circle.fill", withConfiguration: UIImage.SymbolConfiguration(pointSize: largeButtonSize, weight: .medium)), for: .normal)
         primaryButton.tintColor = UIColor.white


### PR DESCRIPTION
Closes: #26 

I had to change the file `EffectDetailsViewController.swift` unrelated with this issue because the project was not compiling. It was missing the `self.` on some properties that was being accessed inside a `DispatchQueue.main.async` block.

The original problem was happening because on `ButtonsViewController` the `drawButtons()` method was being called on `viewDidLoad()`, and at this point, the view's geometry is not yet reliably defined. I made a commit passing it to the `viewDidLayoutSubviews()` method and it did work, but, due to the buttons were fixed by the `frame`, when the device was rotated, the buttons went to a incorrect position, as showed on print:

<img width="500" alt="Screen Shot 2020-10-16 at 6 24 27 PM" src="https://user-images.githubusercontent.com/16858827/96310675-3453de00-0fde-11eb-9af7-f137d89d16c8.png">

So i made another commit with some more changes on `ButtonsViewController` and `ExpandingButtonsView.swift` to arrange the buttons with autolayout constraints. This way, the button's position will automatically adjust themselves to any device's size or orientation:

<img width="500" alt="Screen Shot 2020-10-16 at 6 19 29 PM" src="https://user-images.githubusercontent.com/16858827/96310882-a3313700-0fde-11eb-9680-e9c2a85c0b16.png">

<img width="500" alt="Screen Shot 2020-10-16 at 6 19 46 PM" src="https://user-images.githubusercontent.com/16858827/96310827-85fc6880-0fde-11eb-8f33-3f9104d04503.png">

<img width="500" src = "https://user-images.githubusercontent.com/16858827/96310844-8c8ae000-0fde-11eb-95cf-6faa5bbe3607.png">


